### PR TITLE
Fix Pawn for backwards move

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,11 +1,12 @@
 class Pawn < Piece
   def valid_move?(x, y)
     return false unless on_board?(x, y)
-    return false if backwards_move? y
     return false if horizontal_move? x
     return true if capture_move?(x, y)
     return false if obstructed_vertically?(x, y)
     return true if first_move?(y)
+    return false if color == 'white' && south?(y)
+    return false if color == 'black' && north(y)
 
     proper_length?(y)
   end
@@ -22,8 +23,12 @@ class Pawn < Piece
     x_diff != 0
   end
 
-  def backwards_move?(y)
-    color ? y_coordinate > y : y_coordinate < y
+  def north?(y)
+    ((y_coordinate - y) > 0)
+  end
+
+  def south?(y)
+    ((y_coordinate - y) < 0)
   end
 
   def first_move?(_x, y)

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Pawn, type: :model do
     end
 
     it 'cannot move backwards' do
-      pawn = Pawn.create(x_coordinate: 1, y_coordinate: 1)
-      expect(pawn.backwards_move?(0)).to eq false
+      pawn = Pawn.create(x_coordinate: 4, y_coordinate: 4)
+      expect(pawn.north?(3)).to eq true
     end
 
     it 'cannot move horizontally on the board' do


### PR DESCRIPTION
Was told that others were getting errors on the Pawn backwards move method.  I scrapped that and created a South? and North? method, then check that against the pawns color to determine if it was going in the wrong direction.