### PR TITLE
Gem file cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,52 +5,39 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'pg', '~> 0.18'
-gem 'puma', '~> 3.0'
-gem 'rails', '~> 5.0.1'
-
 gem 'bootstrap-sass', '~> 3.3.5.1'
 gem 'coffee-rails', '~> 4.2'
-gem 'sass-rails'
-gem 'sprockets', '~> 3.0'
-gem 'uglifier', '>= 1.3.0'
-
 gem 'devise', '>= 3.2.4'
-
 gem 'figaro'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
 gem 'omniauth-facebook'
+gem 'pg', '~> 0.18'
+gem 'puma', '~> 3.0'
+gem 'rails', '~> 5.0.1'
 gem 'rails_12factor', group: :production
 gem 'rubocop', '~> 0.47.1', require: false
+gem 'sass-rails'
 gem 'simple_form'
+gem 'sprockets', '~> 3.0'
+gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get
-  # a debugger console
   gem 'byebug', platform: :mri
-  gem 'rspec-rails', '~> 3.5'
-end
-
-group :test do
   gem 'capybara'
   gem 'database_cleaner'
   gem 'factory_girl_rails'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.10.3'
   gem 'pry-rails'
+  gem 'rspec-rails', '~> 3.5'
   gem 'simplecov', require: false
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %>
-  # anywhere in the code.
   gem 'listen', '~> 3.0.5'
-  gem 'web-console', '>= 3.3.0'
-  # Spring speeds up development by keeping your application running in the
-  # background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console', '>= 3.3.0'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,9 +143,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.2)
-      byebug (~> 9.0)
-      pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (2.0.5)
@@ -278,7 +275,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   omniauth-facebook
   pg (~> 0.18)
-  pry-byebug
+  pry (~> 0.10.3)
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.1)


### PR DESCRIPTION
Another go at fixing the pry load error on heroku. Organized the gem files, added pry, and remove pry-byebug because we already have bye bug installed separately.